### PR TITLE
Add DU ecosystem to supported contracts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,9 +25,8 @@
         "@types/mocha": "^9.1.1",
         "@types/node": "^16.11.45",
         "eslint": "^8.19.0",
-        "ethers": "^5.6.9",
-        "hardhat": "^2.9.9",
-        "source-map-support": "^0.5.21",
+        "ethers": "^5.7.0",
+        "hardhat": "^2.10.2",
         "typechain": "^8.1.0",
         "typescript": "~4.7.4"
       },

--- a/src/adapters/dogs-unchained.ts
+++ b/src/adapters/dogs-unchained.ts
@@ -1,0 +1,82 @@
+// Copyright Abridged, Inc. 2022. All Rights Reserved.
+// Node module: @collabland/staking-contracts
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+import {AssetName} from '@collabland/chain';
+import {BindingScope, extensionFor, injectable} from '@loopback/core';
+import {BigNumber} from 'ethers';
+import {STAKING_ADAPTERS_EXTENSION_POINT} from '../keys';
+import {BaseStakingContractAdapter, StakingAsset} from '../staking';
+import {DuStaking} from '../types/DuStaking';
+import {DuStaking__factory} from '../types/factories/DuStaking__factory';
+
+@injectable(
+  {
+    scope: BindingScope.SINGLETON,
+  },
+  extensionFor(STAKING_ADAPTERS_EXTENSION_POINT),
+)
+export class DogsUnchainedStakingContractAdapter extends BaseStakingContractAdapter {
+  contractAddress = '0xd742193c84062c1e0488545fb91a32d220ec6c76';
+  infoAddress = '0x5e2e43585df73a420b5866159f3de2a144c4d51e';
+
+  supportedAssets: StakingAsset[] = [
+    {
+      name: 'Dogs Unchained',
+      asset: 'ERC721:0x9c0ffc9088abeb2ea220d642218874639229fa7a',
+    },
+    {
+      name: 'Proof of Steak',
+      asset: 'ERC721:0xcab65c60d9dc47e1d450c7e9074f73f1ff75f181',
+    },
+    {
+      name: 'Puppies Unchained',
+      asset: 'ERC721:0x948bc723d7e33575427270ac4f26c73b8ba938aa',
+    },
+  ];
+
+  supplies: Record<string, number> = {
+    'Dogs Unchained': 9999,
+    'Proof of Steak': 1405,
+    'Puppies Unchained': 9999,
+  };
+
+  private async getOwnedAssets(
+    contract: DuStaking,
+    asset: StakingAsset,
+    owner: string,
+    maxId: number,
+  ) {
+    const token = new AssetName(asset.asset).reference;
+    return (await contract.getStakedTokens(token, 1, maxId, owner)).filter(x =>
+      x.gt(0),
+    );
+  }
+
+  async getStakedTokenIds(
+    owner: string,
+    assetType = 'Dogs Unchained',
+  ): Promise<BigNumber[]> {
+    const contract = DuStaking__factory.connect(
+      this.infoAddress,
+      this.provider,
+    );
+    let assetIndex = 0; // default to dogs unchained
+    let maxId = 10000;
+    if (assetType.toLowerCase() === 'proof of steak') {
+      assetIndex = 1;
+      maxId = 1405;
+    } else if (assetType.toLowerCase() === 'puppies unchained') {
+      assetIndex = 2;
+      maxId = 10000;
+    }
+    const assets = await this.getOwnedAssets(
+      contract,
+      this.supportedAssets[assetIndex],
+      owner,
+      maxId,
+    );
+    return assets;
+  }
+}

--- a/src/component.ts
+++ b/src/component.ts
@@ -10,6 +10,7 @@ import {
   ServiceOrProviderClass,
 } from '@loopback/core';
 import {CocoStakingContractAdapter} from './adapters/coco.adapter';
+import {DogsUnchainedStakingContractAdapter} from './adapters/dogs-unchained';
 import {PerionCreditsStakingContractAdapter} from './adapters/erc20-staking.adapter';
 import {MtgStakingContractAdapter} from './adapters/mtg.adapter';
 import {RirisuStakingContractAdapter} from './adapters/ririsu.adapter';
@@ -30,6 +31,7 @@ export class StakingContractsComponent implements Component {
     RirisuStakingContractAdapter,
     RoboStakingContractAdapter,
     SkyFarmStakingContractAdapter,
+    DogsUnchainedStakingContractAdapter,
     // NFTWEscrowStakingContractAdapter,
     PerionCreditsStakingContractAdapter,
     // DigitzStakingContractAdapter,

--- a/src/contracts/du-staking.json
+++ b/src/contracts/du-staking.json
@@ -1,0 +1,62 @@
+[
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_stake4boom",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "inputs": [],
+    "name": "stake4boom",
+    "outputs": [
+      {
+        "internalType": "contract Stake4BOOM",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function",
+    "constant": true
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "token",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "minValue",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "maxValue",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      }
+    ],
+    "name": "getStakedTokens",
+    "outputs": [
+      {
+        "internalType": "uint256[]",
+        "name": "",
+        "type": "uint256[]"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function",
+    "constant": true
+  }
+]


### PR DESCRIPTION
Added support for:
- Dogs Unchained
- Proof of Steak
- Puppies Unchained

Each token type requires a single call to an info contract to get ownership for a given address.