### PR TITLE
Add Gen K staking contract adapter

### DIFF
--- a/src/adapters/genk-staking.adapter.ts
+++ b/src/adapters/genk-staking.adapter.ts
@@ -1,0 +1,48 @@
+import {BindingScope, extensionFor, injectable} from '@loopback/core';
+import {BigNumber} from 'ethers';
+import {STAKING_ADAPTERS_EXTENSION_POINT} from '../keys';
+import {BaseStakingContractAdapter, StakingAsset} from '../staking';
+import {GenkStaking__factory} from '../types/factories/GenkStaking__factory';
+
+@injectable(
+  {
+    scope: BindingScope.SINGLETON, // Mark the adapter as a singleton
+  },
+  // Mark it as an extension to staking contracts service
+  extensionFor(STAKING_ADAPTERS_EXTENSION_POINT),
+)
+export class GenKStakingContractAdapter extends BaseStakingContractAdapter {
+  contractAddress = '0x027FC636E944A7a28D58E2d80e5241df546fD9a7';
+  chainId = 137;
+  supportedAssets: StakingAsset[] = [
+    {
+      asset: 'ERC721:0xf8b06f92f147adf01da319304a9d18a2b1b8c9e8',
+    },
+  ];
+
+  /**
+   * Get staked token ids for the given owner
+   * @param owner - Owner address
+   * @returns
+   */
+  async getStakedTokenIds(owner: string): Promise<BigNumber[]> {
+    const contract = GenkStaking__factory.connect(
+      this.contractAddress,
+      this.provider,
+    );
+    return contract.getStakedTokens(owner);
+  }
+
+  /**
+   * Get staked token balance for the given owner
+   * @param owner - Owner address
+   * @returns
+   */
+  async getStakedTokenBalance(owner: string): Promise<BigNumber> {
+    const contract = GenkStaking__factory.connect(
+      this.contractAddress,
+      this.provider,
+    );
+    return BigNumber.from((await contract.getStakedTokens(owner))?.length ?? 0);
+  }
+}

--- a/src/component.ts
+++ b/src/component.ts
@@ -27,6 +27,7 @@ import {Meltdown03ContractAdapter} from './adapters/meltdown.adapter';
 import {AngelBlockStakingContractAdapter} from './adapters/ab.adapter';
 import {BapeliensStakingContractAdapter} from './adapters/bapeliens-staking.adapter';
 import {CbzGrowStakingContractAdapter} from './adapters/cbzgrow.adapter';
+import {GenKStakingContractAdapter} from './adapters/genk-staking.adapter';
 import {MoonrunnersStakingContractAdapter} from './adapters/moonrunners.adapter';
 import {MtgStakingContractAdapter} from './adapters/mtg.adapter';
 import {OmniguardEternalsStakingContractAdapter} from './adapters/omniguard-eternals.adapter';
@@ -80,6 +81,7 @@ export class StakingContractsComponent implements Component {
     ReNFTPolygonSylvesterV1StakingContractAdapter,
     ReplicantXStakingContractAdapter,
     CbzGrowStakingContractAdapter,
+    GenKStakingContractAdapter,
     MeltdownContractAdapter,
     AngelBlockStakingContractAdapter,
     BapeliensStakingContractAdapter,

--- a/src/contracts/genk-staking.json
+++ b/src/contracts/genk-staking.json
@@ -1,0 +1,21 @@
+[
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_user",
+        "type": "address"
+      }
+    ],
+    "name": "getStakedTokens",
+    "outputs": [
+      {
+        "internalType": "uint256[]",
+        "name": "",
+        "type": "uint256[]"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  }
+]


### PR DESCRIPTION
Adds an adapter for the Gen K staking contract, which is part of the Gen K project on Polygon (https://opensea.io/collection/gen-k-1).

Thanks in advance, and just let me know if you need anything else to get this integrated!