### PR TITLE
fix wrong lowercase causing other asset not searchable

### DIFF
--- a/src/adapters/supreme-kong-staking.adapter.ts
+++ b/src/adapters/supreme-kong-staking.adapter.ts
@@ -81,7 +81,7 @@ export class SupremeKongStakingContractAdapter extends BaseStakingContractAdapte
    * @returns
    */
   async getStakedTokenIds(owner: string, name?: string): Promise<BigNumber[]> {
-    name = name?.toLowerCase() ?? 'supremeKong';
+    name = name;
     const poolId = this.poolIds[name] ?? 0;
     const info = await this.contract.stakedNfts(owner, poolId);
     return info;
@@ -91,7 +91,7 @@ export class SupremeKongStakingContractAdapter extends BaseStakingContractAdapte
     owner: string,
     name?: string,
   ): Promise<BigNumber> {
-    name = name?.toLowerCase() ?? 'supremeKong';
+    name = name;
     const poolId = this.poolIds[name] ?? 0;
     const info = await this.contract.stakedNfts(owner, poolId);
     return BigNumber.from(info.length);


### PR DESCRIPTION
- fixing lowercase code on staked asset because asset array not lowercase