### PR TITLE
fix wrong lowercase causing other asset not searchable

### DIFF
--- a/src/adapters/supreme-kong-2-staking.adapter.ts
+++ b/src/adapters/supreme-kong-2-staking.adapter.ts
@@ -63,7 +63,7 @@ export class SupremeKong2StakingContractAdapter extends BaseStakingContractAdapt
    * @returns
    */
   async getStakedTokenIds(owner: string, name?: string): Promise<BigNumber[]> {
-    name = name?.toLowerCase() ?? 'supremeKong2';
+    name = name ?? 'supremeKong2';
     const info = await this.contract.stakedNfts(owner);
     return info;
   }
@@ -72,7 +72,7 @@ export class SupremeKong2StakingContractAdapter extends BaseStakingContractAdapt
     owner: string,
     name?: string,
   ): Promise<BigNumber> {
-    name = name?.toLowerCase() ?? 'supremeKong2';
+    name = name ?? 'supremeKong2';
     const info = await this.contract.stakedNfts(owner);
     return BigNumber.from(info.length);
   }

--- a/src/adapters/supreme-kong-staking.adapter.ts
+++ b/src/adapters/supreme-kong-staking.adapter.ts
@@ -81,7 +81,7 @@ export class SupremeKongStakingContractAdapter extends BaseStakingContractAdapte
    * @returns
    */
   async getStakedTokenIds(owner: string, name?: string): Promise<BigNumber[]> {
-    name = name?.toLowerCase() ?? 'supremeKong';
+    name = name;
     const poolId = this.poolIds[name] ?? 0;
     const info = await this.contract.stakedNfts(owner, poolId);
     return info;
@@ -91,7 +91,7 @@ export class SupremeKongStakingContractAdapter extends BaseStakingContractAdapte
     owner: string,
     name?: string,
   ): Promise<BigNumber> {
-    name = name?.toLowerCase() ?? 'supremeKong';
+    name = name;
     const poolId = this.poolIds[name] ?? 0;
     const info = await this.contract.stakedNfts(owner, poolId);
     return BigNumber.from(info.length);

--- a/src/adapters/supreme-kong-staking.adapter.ts
+++ b/src/adapters/supreme-kong-staking.adapter.ts
@@ -81,7 +81,7 @@ export class SupremeKongStakingContractAdapter extends BaseStakingContractAdapte
    * @returns
    */
   async getStakedTokenIds(owner: string, name?: string): Promise<BigNumber[]> {
-    name = name;
+    name = name ?? 'supremeKong'; // default name will be supreme kong if empty
     const poolId = this.poolIds[name] ?? 0;
     const info = await this.contract.stakedNfts(owner, poolId);
     return info;
@@ -91,7 +91,7 @@ export class SupremeKongStakingContractAdapter extends BaseStakingContractAdapte
     owner: string,
     name?: string,
   ): Promise<BigNumber> {
-    name = name;
+    name = name ?? 'supremeKong'; // default name will be supremekong if empty
     const poolId = this.poolIds[name] ?? 0;
     const info = await this.contract.stakedNfts(owner, poolId);
     return BigNumber.from(info.length);


### PR DESCRIPTION
1. fix lowercase code causing other asset not searchable because default to poolid 0